### PR TITLE
Adjusted readme so it's terraform-registry compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# tf-aws-aurora
+tf-aws-aurora
+---------
 
 AWS Aurora DB Cluster & Instance(s) Terraform Module.
 
@@ -13,12 +14,11 @@ Gives you:
 
 ## Contributing
 
-Ensure any variables you add have a type and a description.
-This README is generated with [terraform-docs](https://github.com/segmentio/terraform-docs):
+Ensure any variables you add have a type and a description, and a default if appropriate.
 
-`terraform-docs md . > README.md`
 
-## Usage example
+Usage example
+---------
 
 ```
 resource "aws_sns_topic" "db_alarms" {
@@ -48,45 +48,52 @@ module "aurora_db" {
 ```
 
 
-## Inputs
+Inputs
+---------
+_Variables marked with __[*]__ are mandatory._
 
-| Name | Description | Default | Required |
-|------|-------------|:-----:|:-----:|
-| apply_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | `false` | no |
-| auto_minor_version_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | `true` | no |
-| azs | List of AZs to use | - | yes |
-| backup_retention_period | How long to keep backups for (in days) | `7` | no |
-| cw_alarms | Whether to enable CloudWatch alarms - requires `cw_sns_topic` is specified | `false` | no |
-| cw_max_conns | Connection count beyond which to trigger a CloudWatch alarm | `500` | no |
-| cw_max_cpu | CPU threshold above which to alarm | `85` | no |
-| cw_max_replica_lag | Maximum Aurora replica lag in milliseconds above which to alarm | `2000` | no |
-| cw_sns_topic | An SNS topic to publish CloudWatch alarms to | `false` | no |
-| db_cluster_parameter_group_name | The name of a DB Cluster parameter group to use | `default.aurora5.6` | no |
-| db_parameter_group_name | The name of a DB parameter group to use | `default.aurora5.6` | no |
-| envname | Environment name (eg,test, stage or prod) | - | yes |
-| envtype | Environment type (eg,prod or nonprod) | - | yes |
-| final_snapshot_identifier | The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `final_snapshot` | no |
-| instance_type | Instance type to use | `db.t2.small` | no |
-| monitoring_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `0` | no |
-| name | Name given to DB subnet group | - | yes |
-| password | Master DB password | - | yes |
-| port | The port on which to accept connections | `3306` | no |
-| preferred_backup_window | When to perform DB backups | `02:00-03:00` | no |
-| preferred_maintenance_window | When to perform DB maintenance | `sun:05:00-sun:06:00` | no |
-| publicly_accessible | Whether the DB should have a public IP address | `false` | no |
-| replica_count | Number of reader nodes to create | `0` | no |
-| security_groups | VPC Security Group IDs | - | yes |
-| skip_final_snapshot | Should a final snapshot be created on cluster destroy | `false` | no |
-| snapshot_identifier | DB snapshot to create this database from | `` | no |
-| storage_encrypted | Specifies whether the underlying storage layer should be encrypted | `true` | no |
-| subnets | List of subnet IDs to use | - | yes |
-| username | Master DB username | `root` | no |
+###### Environment
+ - `envname` - Environment name (e.g. `test`, `staging`). __[*]__
+ - `envtype` - Environment type (e.g. `prod`, `nonprod`). __[*]__
+ - `azs` - List of AZs to use. __[*]__
 
-## Outputs
+###### Cloudwatch variables
+ - `cw_alarms` - Whether to enable CloudWatch alarms - requires `cw_sns_topic` is specified. [Default: `false`]
+ - `cw_sns_topic` - An SNS topic to publish CloudWatch alarms to. [__*__ unless `cw_alarms` is `false`]
+ - `cw_max_conns` - Connection count beyond which to trigger a CloudWatch alarm. [Default: `500`]
+ - `cw_max_cpu` - CPU threshold above which to alarm. [Default: `85`]
+ - `cw_max_replica_lag` - Maximum Aurora replica lag in milliseconds above which to alarm. [Default: `2000`]
 
-| Name | Description |
-|------|-------------|
-| all_instance_endpoints_list | Comma separated list of all DB instance endpoints running in cluster |
-| cluster_endpoint | The 'writer' endpoint for the cluster |
-| reader_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
+###### Instance and Network 
+ - `instance_type` - Instance type to use. [Default: `db.t2.small`]
+ - `name` - Name given to DB subnet group. __[*]__
+ - `subnets` - List of subnet IDs to use. __[*]__
+ - `publicly_accessible` - Whether the DB should have a public IP address. [Default: `false`]
+ - `security_groups` - VPC Security Group IDs. __[*]__
 
+###### Aurora variables
+ - `username` - Master DB username. [Default: `root`]
+ - `password` - Master DB password. __[*]__
+ - `port` - The port on which to accept connections. [Default: `3306`]
+ - `replica_count` - Number of reader nodes to create. [Default: `0`]
+ - `storage_encrypted` - Specifies whether the underlying storage layer should be encrypted. [Default: `true`]
+ - `db_cluster_parameter_group_name` - The name of a DB Cluster parameter group to use. [Default: `default.aurora5.6`]
+ - `db_parameter_group_name` - The name of a DB parameter group to use. [Default: `default.aurora5.6`]
+ - `monitoring_interval` - The interval (seconds) between points when Enhanced Monitoring metrics are collected. [Default: `0`]
+ - `backup_retention_period` - How long to keep backups for (in days). [Default: `7`]
+
+###### Backup, maintenance and snapshots
+ - `preferred_backup_window` - When to perform DB backups. [Default: `02:00-03:00`]
+ - `preferred_maintenance_window` - When to perform DB maintenance. [Default: `sun:05:00-sun:06:00`]
+ - `skip_final_snapshot` - Should a final snapshot be created on cluster destroy. [Default: `false`]
+ - `snapshot_identifier` - DB snapshot to create this database from. [Default: '']
+ - `final_snapshot_identifier` - The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. [Default: `final_snapshot`]
+ - `apply_immediately` - Determines whether or not any DB modifications are applied immediately, or during the maintenance window. [Default: `false`]
+ - `auto_minor_version_upgrade` - Determines whether minor engine upgrades will be performed automatically in the maintenance window. [Default: `false`]
+
+Outputs
+---------
+
+ - `all_instance_endpoints_list` - Comma separated list of all DB instance endpoints running in cluster.
+ - `cluster_endpoint` - The 'writer' endpoint for the cluster.
+ - `reader_endpoint` - A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas.


### PR DESCRIPTION
When viewing the [Inputs|Outputs] sections of this module on the [terraform registry](https://registry.terraform.io/modules/claranet/aurora/aws/1.0.2), the markdown tables formatting gets badly misinterpreted. 

![image](https://user-images.githubusercontent.com/8448933/31077567-e6033822-a776-11e7-87e9-796e8ec62988.png)

This PR contains a rework of the readme to allow the registry to better parse it as well as removing the '...module readme made by terraform-docs...' line because it's no longer strictly true.


