### PR TITLE
Aurora 5.7 version info

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -220,6 +220,7 @@ resource "aws_rds_cluster" "default" {
   cluster_identifier              = "${var.identifier_prefix != "" ? format("%s-cluster", var.identifier_prefix) : format("%s-aurora-cluster", var.envname)}"
   availability_zones              = ["${var.azs}"]
   engine                          = "${var.engine}"
+  engine_version                  = "${var.engine-version}"
   master_username                 = "${var.username}"
   master_password                 = "${var.password}"
   final_snapshot_identifier       = "${var.final_snapshot_identifier}-${random_id.server.hex}"


### PR DESCRIPTION
Hi,
I did it some time ago, but AFAIR it didn't want to work for aurora 5.7.
In the main.tf for the `aws_rds_cluster` you do not specify a reference to a variable for `engine_version` so it won't be taken into account and will always use aurora-5.6.
Cheers,
M