### PR TITLE
Add lifecycle ignore on az's

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -241,6 +241,12 @@ resource "aws_rds_cluster" "default" {
   storage_encrypted               = "${var.storage_encrypted}"
   apply_immediately               = "${var.apply_immediately}"
   db_cluster_parameter_group_name = "${var.db_cluster_parameter_group_name}"
+
+  lifecycle {
+    ignore_changes = [
+      "availability_zones",
+    ]
+  }
 }
 
 // Geneate an ID when an environment is initialised

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,7 @@ variable "identifier_prefix" {
 variable "azs" {
   type        = "list"
   description = "List of AZs to use"
+  default     = []
 }
 
 variable "replica_count" {


### PR DESCRIPTION
If you leave `azs` parameter off, it chooses the minimum which is great. However, any subsequent runs show a delete/create since the module wants to set to `0` but there are >1 set by the API:

```
-/+ module.db.aws_rds_cluster.default (new resource required)                                              
      id:                                  "aurora-cluster" => <computed> (forces new resource)                             
      apply_immediately:                   "true" => "true"                                                                             
      availability_zones.#:                "3" => "0" (forces new resource)                                                          
      availability_zones.1305112097:       "us-east-1b" => "" (forces new resource)                        
      availability_zones.3551460226:       "us-east-1e" => "" (forces new resource)                                                       
      availability_zones.3569565595:       "us-east-1a" => "" (forces new resource)                                                                    
      backup_retention_period:             "5" => "5"          
```