### PR TITLE
explicitly set the postgres port

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ module "aurora_db_postgres96" {
   replica_count                   = "1"
   security_groups                 = ["${aws_security_group.allow_all.id}"]
   instance_type                   = "db.r4.large"
+  port                            = "5432"
   username                        = "root"
   password                        = "changeme"
   backup_retention_period         = "5"

--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,7 @@
   *   replica_count                   = "1"
   *   security_groups                 = ["${aws_security_group.allow_all.id}"]
   *   instance_type                   = "db.r4.large"
+  *   port                            = "5432"
   *   username                        = "root"
   *   password                        = "changeme"
   *   backup_retention_period         = "5"


### PR DESCRIPTION
otherwise, users of the recipe will bring up a postgres instance listening on 3306.