### PR TITLE
Allow renaming of the enhanced monitoring role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -268,7 +268,7 @@ data "aws_iam_policy_document" "monitoring-rds-assume-role-policy" {
 
 resource "aws_iam_role" "rds-enhanced-monitoring" {
   count              = "${var.monitoring_interval > 0 ? 1 : 0}"
-  name               = "rds-enhanced-monitoring-${var.envname}"
+  name               = "${var.enhanced_monitoring_role_name == "" ? format("rds-enhanced-monitoring-%s", var.envname) : var.enhanced_monitoring_role_name}"
   assume_role_policy = "${data.aws_iam_policy_document.monitoring-rds-assume-role-policy.json}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,9 @@ variable "performance_insights_enabled" {
   default     = false
   description = "Whether to enable Performance Insights"
 }
+
+variable "enhanced_monitoring_role_name" {
+  description = "The name to use when creating the enhanced monitoring IAM role."
+  type        = "string"
+  default     = ""
+}


### PR DESCRIPTION
The enhanced monitoring role name can clash if you have
clusters in multiple regions. This change allows for you to rename the
role so it does not clash with the other roles.