### PR TITLE
Add IAM database authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ AWS doesn't automatically remove RDS instances created from autoscaling when you
 
 ### Aurora 1.x (MySQL 5.6)
 
-```
+```hcl
 resource "aws_sns_topic" "db_alarms_56" {
   name = "aurora-db-alarms-56"
 }
@@ -184,6 +184,7 @@ resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres96_parameter_
 | envname | Environment name (eg,test, stage or prod) | string | - | yes |
 | envtype | Environment type (eg,prod or nonprod) | string | - | yes |
 | final_snapshot_identifier | The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | string | `final` | no |
+| iam_database_authentication_enabled | Whether to enable IAM database authentication for the RDS Cluster | string | `false` | no |
 | identifier_prefix | Prefix for cluster and instance identifier | string | `` | no |
 | instance_type | Instance type to use | string | `db.t2.small` | no |
 | monitoring_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | string | `0` | no |

--- a/main.tf
+++ b/main.tf
@@ -232,21 +232,22 @@ resource "aws_rds_cluster" "default" {
   availability_zones = ["${var.azs}"]
   engine             = "${var.engine}"
 
-  engine_version                  = "${var.engine-version}"
-  master_username                 = "${var.username}"
-  master_password                 = "${var.password}"
-  final_snapshot_identifier       = "${var.final_snapshot_identifier}-${random_id.server.hex}"
-  skip_final_snapshot             = "${var.skip_final_snapshot}"
-  backup_retention_period         = "${var.backup_retention_period}"
-  preferred_backup_window         = "${var.preferred_backup_window}"
-  preferred_maintenance_window    = "${var.preferred_maintenance_window}"
-  port                            = "${var.port}"
-  db_subnet_group_name            = "${aws_db_subnet_group.main.name}"
-  vpc_security_group_ids          = ["${var.security_groups}"]
-  snapshot_identifier             = "${var.snapshot_identifier}"
-  storage_encrypted               = "${var.storage_encrypted}"
-  apply_immediately               = "${var.apply_immediately}"
-  db_cluster_parameter_group_name = "${var.db_cluster_parameter_group_name}"
+  engine_version                      = "${var.engine-version}"
+  master_username                     = "${var.username}"
+  master_password                     = "${var.password}"
+  final_snapshot_identifier           = "${var.final_snapshot_identifier}-${random_id.server.hex}"
+  skip_final_snapshot                 = "${var.skip_final_snapshot}"
+  backup_retention_period             = "${var.backup_retention_period}"
+  preferred_backup_window             = "${var.preferred_backup_window}"
+  preferred_maintenance_window        = "${var.preferred_maintenance_window}"
+  port                                = "${var.port}"
+  db_subnet_group_name                = "${aws_db_subnet_group.main.name}"
+  vpc_security_group_ids              = ["${var.security_groups}"]
+  snapshot_identifier                 = "${var.snapshot_identifier}"
+  storage_encrypted                   = "${var.storage_encrypted}"
+  apply_immediately                   = "${var.apply_immediately}"
+  db_cluster_parameter_group_name     = "${var.db_cluster_parameter_group_name}"
+  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
 }
 
 // Geneate an ID when an environment is initialised
@@ -272,7 +273,7 @@ data "aws_iam_policy_document" "monitoring-rds-assume-role-policy" {
 
 resource "aws_iam_role" "rds-enhanced-monitoring" {
   count              = "${var.monitoring_interval > 0 ? 1 : 0}"
-  name_prefix        = "rds-enhanced-monitoring-${var.envname}-"
+  name_prefix        = "rds-enhanced-mon-${var.envname}-"
   assume_role_policy = "${data.aws_iam_policy_document.monitoring-rds-assume-role-policy.json}"
 }
 

--- a/tests/terraform/test-mysql-56.tf
+++ b/tests/terraform/test-mysql-56.tf
@@ -3,26 +3,27 @@ resource "aws_sns_topic" "db_alarms_56" {
 }
 
 module "aurora_db_56" {
-  source                          = "../.."
-  name                            = "test-aurora-db-56"
-  envname                         = "test56"
-  envtype                         = "test"
-  subnets                         = ["${module.vpc.private_subnets}"]
-  azs                             = ["${module.vpc.availability_zones}"]
-  replica_count                   = "1"
-  security_groups                 = ["${aws_security_group.allow_all.id}"]
-  instance_type                   = "db.t2.medium"
-  username                        = "root"
-  password                        = "changeme"
-  backup_retention_period         = "5"
-  final_snapshot_identifier       = "final-db-snapshot-prod"
-  storage_encrypted               = "true"
-  apply_immediately               = "true"
-  monitoring_interval             = "10"
-  cw_alarms                       = true
-  cw_sns_topic                    = "${aws_sns_topic.db_alarms_56.id}"
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_56_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_cluster_56_parameter_group.id}"
+  source                              = "../.."
+  name                                = "test-aurora-db-56"
+  envname                             = "test56"
+  envtype                             = "test"
+  subnets                             = ["${module.vpc.private_subnets}"]
+  azs                                 = ["${module.vpc.availability_zones}"]
+  replica_count                       = "1"
+  security_groups                     = ["${aws_security_group.allow_all.id}"]
+  instance_type                       = "db.t2.medium"
+  username                            = "root"
+  password                            = "changeme"
+  backup_retention_period             = "5"
+  final_snapshot_identifier           = "final-db-snapshot-prod"
+  storage_encrypted                   = "true"
+  apply_immediately                   = "true"
+  monitoring_interval                 = "10"
+  cw_alarms                           = true
+  cw_sns_topic                        = "${aws_sns_topic.db_alarms_56.id}"
+  db_parameter_group_name             = "${aws_db_parameter_group.aurora_db_56_parameter_group.id}"
+  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.aurora_cluster_56_parameter_group.id}"
+  iam_database_authentication_enabled = "true"
 }
 
 resource "aws_db_parameter_group" "aurora_db_56_parameter_group" {

--- a/tests/terraform/test-mysql-57-autoscaling.tf
+++ b/tests/terraform/test-mysql-57-autoscaling.tf
@@ -3,33 +3,34 @@ resource "aws_sns_topic" "db_alarms_57_autoscaling" {
 }
 
 module "aurora_db_57_autoscaling" {
-  source                          = "../.."
-  engine                          = "aurora-mysql"
-  engine-version                  = "5.7.12"
-  name                            = "test-aurora-db-57-autoscaling"
-  envname                         = "test-57-autoscaling"
-  envtype                         = "test"
-  subnets                         = ["${module.vpc.private_subnets}"]
-  azs                             = ["${module.vpc.availability_zones}"]
-  security_groups                 = ["${aws_security_group.allow_all.id}"]
-  instance_type                   = "db.t2.medium"
-  username                        = "root"
-  password                        = "changeme"
-  backup_retention_period         = "5"
-  final_snapshot_identifier       = "final-db-snapshot-prod"
-  storage_encrypted               = "true"
-  apply_immediately               = "true"
-  monitoring_interval             = "10"
-  cw_alarms                       = true
-  cw_sns_topic                    = "${aws_sns_topic.db_alarms_57_autoscaling.id}"
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_57_autoscaling_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_57_autoscaling_cluster_parameter_group.id}"
-  replica_scale_enabled           = true
-  replica_scale_min               = "1"
-  replica_scale_max               = "1"
-  replica_scale_cpu               = "70"
-  replica_scale_in_cooldown       = "300"
-  replica_scale_out_cooldown      = "300"
+  source                              = "../.."
+  engine                              = "aurora-mysql"
+  engine-version                      = "5.7.12"
+  name                                = "aurora-my57-asg"
+  envname                             = "test-57-asg"
+  envtype                             = "test"
+  subnets                             = ["${module.vpc.private_subnets}"]
+  azs                                 = ["${module.vpc.availability_zones}"]
+  security_groups                     = ["${aws_security_group.allow_all.id}"]
+  instance_type                       = "db.t2.medium"
+  username                            = "root"
+  password                            = "changeme"
+  backup_retention_period             = "5"
+  final_snapshot_identifier           = "final-db-snapshot-prod"
+  storage_encrypted                   = "true"
+  apply_immediately                   = "true"
+  monitoring_interval                 = "10"
+  cw_alarms                           = true
+  cw_sns_topic                        = "${aws_sns_topic.db_alarms_57_autoscaling.id}"
+  db_parameter_group_name             = "${aws_db_parameter_group.aurora_db_57_autoscaling_parameter_group.id}"
+  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.aurora_57_autoscaling_cluster_parameter_group.id}"
+  replica_scale_enabled               = true
+  replica_scale_min                   = "1"
+  replica_scale_max                   = "1"
+  replica_scale_cpu                   = "70"
+  replica_scale_in_cooldown           = "300"
+  replica_scale_out_cooldown          = "300"
+  iam_database_authentication_enabled = "true"
 }
 
 resource "aws_db_parameter_group" "aurora_db_57_autoscaling_parameter_group" {

--- a/tests/terraform/test-mysql-57.tf
+++ b/tests/terraform/test-mysql-57.tf
@@ -3,28 +3,29 @@ resource "aws_sns_topic" "db_alarms" {
 }
 
 module "aurora_db_57" {
-  source                          = "../.."
-  engine                          = "aurora-mysql"
-  engine-version                  = "5.7.12"
-  name                            = "test-aurora-db-57"
-  envname                         = "test-57"
-  envtype                         = "test"
-  subnets                         = ["${module.vpc.private_subnets}"]
-  azs                             = ["${module.vpc.availability_zones}"]
-  replica_count                   = "1"
-  security_groups                 = ["${aws_security_group.allow_all.id}"]
-  instance_type                   = "db.t2.medium"
-  username                        = "root"
-  password                        = "changeme"
-  backup_retention_period         = "5"
-  final_snapshot_identifier       = "final-db-snapshot-prod"
-  storage_encrypted               = "true"
-  apply_immediately               = "true"
-  monitoring_interval             = "10"
-  cw_alarms                       = true
-  cw_sns_topic                    = "${aws_sns_topic.db_alarms.id}"
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_57_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id}"
+  source                              = "../.."
+  engine                              = "aurora-mysql"
+  engine-version                      = "5.7.12"
+  name                                = "test-aurora-db-57"
+  envname                             = "test-57"
+  envtype                             = "test"
+  subnets                             = ["${module.vpc.private_subnets}"]
+  azs                                 = ["${module.vpc.availability_zones}"]
+  replica_count                       = "1"
+  security_groups                     = ["${aws_security_group.allow_all.id}"]
+  instance_type                       = "db.t2.medium"
+  username                            = "root"
+  password                            = "changeme"
+  backup_retention_period             = "5"
+  final_snapshot_identifier           = "final-db-snapshot-prod"
+  storage_encrypted                   = "true"
+  apply_immediately                   = "true"
+  monitoring_interval                 = "10"
+  cw_alarms                           = true
+  cw_sns_topic                        = "${aws_sns_topic.db_alarms.id}"
+  db_parameter_group_name             = "${aws_db_parameter_group.aurora_db_57_parameter_group.id}"
+  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id}"
+  iam_database_authentication_enabled = "true"
 }
 
 resource "aws_db_parameter_group" "aurora_db_57_parameter_group" {

--- a/tests/terraform/test-postgres.tf
+++ b/tests/terraform/test-postgres.tf
@@ -3,28 +3,29 @@ resource "aws_sns_topic" "db_alarms_postgres96" {
 }
 
 module "aurora_db_postgres96" {
-  source                          = "../.."
-  engine                          = "aurora-postgresql"
-  engine-version                  = "9.6.6"
-  name                            = "test-aurora-db-postgres96"
-  envname                         = "test-pg96"
-  envtype                         = "test"
-  subnets                         = ["${module.vpc.private_subnets}"]
-  azs                             = ["${module.vpc.availability_zones}"]
-  replica_count                   = "1"
-  security_groups                 = ["${aws_security_group.allow_all.id}"]
-  instance_type                   = "db.r4.large"
-  username                        = "root"
-  password                        = "changeme"
-  backup_retention_period         = "5"
-  final_snapshot_identifier       = "final-db-snapshot-prod"
-  storage_encrypted               = "true"
-  apply_immediately               = "true"
-  monitoring_interval             = "10"
-  cw_alarms                       = true
-  cw_sns_topic                    = "${aws_sns_topic.db_alarms_postgres96.id}"
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_postgres96_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id}"
+  source                              = "../.."
+  engine                              = "aurora-postgresql"
+  engine-version                      = "9.6.6"
+  name                                = "test-aurora-db-postgres96"
+  envname                             = "test-pg96"
+  envtype                             = "test"
+  subnets                             = ["${module.vpc.private_subnets}"]
+  azs                                 = ["${module.vpc.availability_zones}"]
+  replica_count                       = "1"
+  security_groups                     = ["${aws_security_group.allow_all.id}"]
+  instance_type                       = "db.r4.large"
+  username                            = "root"
+  password                            = "changeme"
+  backup_retention_period             = "5"
+  final_snapshot_identifier           = "final-db-snapshot-prod"
+  storage_encrypted                   = "true"
+  apply_immediately                   = "true"
+  monitoring_interval                 = "10"
+  cw_alarms                           = true
+  cw_sns_topic                        = "${aws_sns_topic.db_alarms_postgres96.id}"
+  db_parameter_group_name             = "${aws_db_parameter_group.aurora_db_postgres96_parameter_group.id}"
+  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id}"
+  iam_database_authentication_enabled = "false"
 }
 
 resource "aws_db_parameter_group" "aurora_db_postgres96_parameter_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,9 @@ variable "performance_insights_enabled" {
   default     = false
   description = "Whether to enable Performance Insights"
 }
+
+variable "iam_database_authentication_enabled" {
+  type        = "string"
+  default     = false
+  description = "Whether to enable IAM database authentication for the RDS Cluster"
+}


### PR DESCRIPTION
Add IAM database authentication support as per:
https://www.terraform.io/docs/providers/aws/r/rds_cluster.html#iam_database_authentication_enabled

Note that I have adjusted:

https://github.com/claranet/terraform-aws-aurora/compare/ajj/iam-database-authentication?expand=1#diff-7a370d8342e7203b805911c92454f0f4R276

To be shorter as it was causing issues for the tests due to a maximum name length limit. I have abbreviated it to reduce the chance this will cause issues.

Also note that I have intentionally set IAM database authentication to disabled for the Postgres test as it is not supported by the Postgres version that we test the module against.