### PR TITLE
added support for tags

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -253,3 +253,9 @@ variable "enabled" {
   default     = true
   description = "Whether the database resources should be created"
 }
+
+variable "tags" {
+  type        = "map"
+  description = "Map of tags to apply to RDS cluster and resources"
+  default     = {}
+}


### PR DESCRIPTION
added support for custom tags

This module only tags envtype and envname on select resources. I made a backwards compatible change that allows developers to pass in their own set of standard tags which then gets merged with the default envtype and envname tags.

Tags are also applied to any RDS resource that supports them. This way all related resources are tagged appropriately.