### PR TITLE
Adding Terraform 0.12 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ This README is generated with [terraform-docs](https://github.com/segmentio/terr
 
 `terraform-docs md . > README.md`
 
+## Terraform version compatibility
+
+| Module version | Terraform version |
+|----------------|-------------------|
+| 4.x.x          | 0.12.x            |
+| 3.x.x          | 0.11.x            |
+
 ## Usage examples
 
 *It is recommended you always create a parameter group, even if it exactly matches the defaults.*
@@ -29,6 +36,7 @@ AWS doesn't automatically remove RDS instances created from autoscaling when you
 
 ## Breaking changes
 
+* Version 4.0.0 onwards will only support Terraform 0.12 and above.
 * As of version 3.0.0 of the module the rds-enhanced-monitoring role is now named using a name_prefix instead of a name. This will result in the role being recreated with a new name when you update to it.
 
 ### Aurora 1.x (MySQL 5.6)
@@ -39,26 +47,27 @@ resource "aws_sns_topic" "db_alarms_56" {
 }
 
 module "aurora_db_56" {
-  source                          = "claranet/aurora/aws"
-  name                            = "test-aurora-db-56"
-  envname                         = "test56"
-  envtype                         = "test"
-  subnets                         = ["${module.vpc.private_subnets}"]
-  azs                             = ["${module.vpc.availability_zones}"]
-  replica_count                   = "1"
-  security_groups                 = ["${aws_security_group.allow_all.id}"]
-  instance_type                   = "db.t2.medium"
-  username                        = "root"
-  password                        = "changeme"
-  backup_retention_period         = "5"
-  final_snapshot_identifier       = "final-db-snapshot-prod"
-  storage_encrypted               = "true"
-  apply_immediately               = "true"
-  monitoring_interval             = "10"
-  cw_alarms                       = true
-  cw_sns_topic                    = "${aws_sns_topic.db_alarms_56.id}"
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_56_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_cluster_56_parameter_group.id}"
+  source                              = "../.."
+  name                                = "test-aurora-db-56"
+  envname                             = "test56"
+  envtype                             = "test"
+  subnets                             = module.vpc.private_subnet_ids
+  azs                                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  replica_count                       = "1"
+  security_groups                     = [aws_security_group.allow_all.id]
+  instance_type                       = "db.t2.medium"
+  username                            = "root"
+  password                            = "changeme"
+  backup_retention_period             = "5"
+  final_snapshot_identifier           = "final-db-snapshot-prod"
+  storage_encrypted                   = "true"
+  apply_immediately                   = "true"
+  monitoring_interval                 = "10"
+  cw_alarms                           = true
+  cw_sns_topic                        = aws_sns_topic.db_alarms_56.id
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_56_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_cluster_56_parameter_group.id
+  iam_database_authentication_enabled = "true"
 }
 
 resource "aws_db_parameter_group" "aurora_db_56_parameter_group" {
@@ -82,28 +91,29 @@ resource "aws_sns_topic" "db_alarms" {
 }
 
 module "aurora_db_57" {
-  source                          = "claranet/aurora/aws"
-  engine                          = "aurora-mysql"
-  engine-version                  = "5.7.12"
-  name                            = "test-aurora-db-57"
-  envname                         = "test-57"
-  envtype                         = "test"
-  subnets                         = ["${module.vpc.private_subnets}"]
-  azs                             = ["${module.vpc.availability_zones}"]
-  replica_count                   = "1"
-  security_groups                 = ["${aws_security_group.allow_all.id}"]
-  instance_type                   = "db.t2.medium"
-  username                        = "root"
-  password                        = "changeme"
-  backup_retention_period         = "5"
-  final_snapshot_identifier       = "final-db-snapshot-prod"
-  storage_encrypted               = "true"
-  apply_immediately               = "true"
-  monitoring_interval             = "10"
-  cw_alarms                       = true
-  cw_sns_topic                    = "${aws_sns_topic.db_alarms.id}"
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_57_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id}"
+  source                              = "../.."
+  engine                              = "aurora-mysql"
+  engine-version                      = "5.7.12"
+  name                                = "test-aurora-db-57"
+  envname                             = "test-57"
+  envtype                             = "test"
+  subnets                             = module.vpc.private_subnet_ids
+  azs                                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  replica_count                       = "1"
+  security_groups                     = [aws_security_group.allow_all.id]
+  instance_type                       = "db.t2.medium"
+  username                            = "root"
+  password                            = "changeme"
+  backup_retention_period             = "5"
+  final_snapshot_identifier           = "final-db-snapshot-prod"
+  storage_encrypted                   = "true"
+  apply_immediately                   = "true"
+  monitoring_interval                 = "10"
+  cw_alarms                           = true
+  cw_sns_topic                        = aws_sns_topic.db_alarms.id
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_57_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id
+  iam_database_authentication_enabled = "true"
 }
 
 resource "aws_db_parameter_group" "aurora_db_57_parameter_group" {
@@ -126,28 +136,29 @@ resource "aws_sns_topic" "db_alarms_postgres96" {
 }
 
 module "aurora_db_postgres96" {
-  source                          = "claranet/aurora/aws"
-  engine                          = "aurora-postgresql"
-  engine-version                  = "9.6.3"
-  name                            = "test-aurora-db-postgres96"
-  envname                         = "test-pg96"
-  envtype                         = "test"
-  subnets                         = ["${module.vpc.private_subnets}"]
-  azs                             = ["${module.vpc.availability_zones}"]
-  replica_count                   = "1"
-  security_groups                 = ["${aws_security_group.allow_all.id}"]
-  instance_type                   = "db.r4.large"
-  username                        = "root"
-  password                        = "changeme"
-  backup_retention_period         = "5"
-  final_snapshot_identifier       = "final-db-snapshot-prod"
-  storage_encrypted               = "true"
-  apply_immediately               = "true"
-  monitoring_interval             = "10"
-  cw_alarms                       = true
-  cw_sns_topic                    = "${aws_sns_topic.db_alarms_postgres96.id}"
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_postgres96_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id}"
+  source                              = "../.."
+  engine                              = "aurora-postgresql"
+  engine-version                      = "9.6.6"
+  name                                = "test-aurora-db-postgres96"
+  envname                             = "test-pg96"
+  envtype                             = "test"
+  subnets                             = module.vpc.private_subnet_ids
+  azs                                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  replica_count                       = "1"
+  security_groups                     = [aws_security_group.allow_all.id]
+  instance_type                       = "db.r4.large"
+  username                            = "root"
+  password                            = "changeme"
+  backup_retention_period             = "5"
+  final_snapshot_identifier           = "final-db-snapshot-prod"
+  storage_encrypted                   = "true"
+  apply_immediately                   = "true"
+  monitoring_interval                 = "10"
+  cw_alarms                           = true
+  cw_sns_topic                        = aws_sns_topic.db_alarms_postgres96.id
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_postgres96_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id
+  iam_database_authentication_enabled = "false"
 }
 
 resource "aws_db_parameter_group" "aurora_db_postgres96_parameter_group" {
@@ -162,63 +173,61 @@ resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres96_parameter_
   description = "test-aurora-postgres96-cluster-parameter-group"
 }
 ```
-
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| apply_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | string | `false` | no |
-| auto_minor_version_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `true` | no |
-| azs | List of AZs to use | list | - | yes |
-| backup_retention_period | How long to keep backups for (in days) | string | `7` | no |
-| cw_alarms | Whether to enable CloudWatch alarms - requires `cw_sns_topic` is specified | string | `false` | no |
-| cw_eval_period_connections | Evaluation period for the DB connections alarms | string | `1` | no |
-| cw_eval_period_cpu | Evaluation period for the DB CPU alarms | string | `2` | no |
-| cw_eval_period_replica_lag | Evaluation period for the DB replica lag alarm | string | `5` | no |
-| cw_max_conns | Connection count beyond which to trigger a CloudWatch alarm | string | `500` | no |
-| cw_max_cpu | CPU threshold above which to alarm | string | `85` | no |
-| cw_max_replica_lag | Maximum Aurora replica lag in milliseconds above which to alarm | string | `2000` | no |
-| cw_sns_topic | An SNS topic to publish CloudWatch alarms to | string | `false` | no |
-| db_cluster_parameter_group_name | The name of a DB Cluster parameter group to use | string | `default.aurora5.6` | no |
-| db_parameter_group_name | The name of a DB parameter group to use | string | `default.aurora5.6` | no |
-| enabled | Whether the database resources should be created | string | `true`| no |
-| engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | string | `aurora` | no |
-| engine-version | Aurora database engine version. | string | `5.6.10a` | no |
-| envname | Environment name (eg,test, stage or prod) | string | - | yes |
-| envtype | Environment type (eg,prod or nonprod) | string | - | yes |
-| final_snapshot_identifier | The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | string | `final` | no |
-| iam_database_authentication_enabled | Whether to enable IAM database authentication for the RDS Cluster | string | `false` | no |
-| identifier_prefix | Prefix for cluster and instance identifier | string | `` | no |
-| instance_type | Instance type to use | string | `db.t2.small` | no |
-| monitoring_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | string | `0` | no |
-| name | Name given to DB subnet group | string | - | yes |
-| password | Master DB password | string | - | yes |
-| performance_insights_enabled | Whether to enable Performance Insights | string | `false` | no |
-| port | The port on which to accept connections | string | `3306` | no |
-| preferred_backup_window | When to perform DB backups | string | `02:00-03:00` | no |
-| preferred_maintenance_window | When to perform DB maintenance | string | `sun:05:00-sun:06:00` | no |
-| publicly_accessible | Whether the DB should have a public IP address | string | `false` | no |
-| replica_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | string | `0` | no |
-| replica_scale_cpu | CPU usage to trigger autoscaling at | string | `70` | no |
-| replica_scale_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | string | `false` | no |
-| replica_scale_in_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | string | `300` | no |
-| replica_scale_max | Maximum number of replicas to allow scaling for | string | `0` | no |
-| replica_scale_min | Maximum number of replicas to allow scaling for | string | `2` | no |
-| replica_scale_out_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | string | `300` | no |
-| security_groups | VPC Security Group IDs | list | - | yes |
-| skip_final_snapshot | Should a final snapshot be created on cluster destroy | string | `false` | no |
-| snapshot_identifier | DB snapshot to create this database from | string | `` | no |
-| storage_encrypted | Specifies whether the underlying storage layer should be encrypted | string | `true` | no |
-| subnets | List of subnet IDs to use | list | - | yes |
-| username | Master DB username | string | `root` | no |
+| apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | string | `"false"` | no |
+| auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `"true"` | no |
+| azs | List of AZs to use | list(string) | n/a | yes |
+| backup\_retention\_period | How long to keep backups for (in days) | string | `"7"` | no |
+| cw\_alarms | Whether to enable CloudWatch alarms - requires `cw_sns_topic` is specified | string | `"false"` | no |
+| cw\_eval\_period\_connections | Evaluation period for the DB connections alarms | string | `"1"` | no |
+| cw\_eval\_period\_cpu | Evaluation period for the DB CPU alarms | string | `"2"` | no |
+| cw\_eval\_period\_replica\_lag | Evaluation period for the DB replica lag alarm | string | `"5"` | no |
+| cw\_max\_conns | Connection count beyond which to trigger a CloudWatch alarm | string | `"500"` | no |
+| cw\_max\_cpu | CPU threshold above which to alarm | string | `"85"` | no |
+| cw\_max\_replica\_lag | Maximum Aurora replica lag in milliseconds above which to alarm | string | `"2000"` | no |
+| cw\_sns\_topic | An SNS topic to publish CloudWatch alarms to | string | `"false"` | no |
+| db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | string | `"default.aurora5.6"` | no |
+| db\_parameter\_group\_name | The name of a DB parameter group to use | string | `"default.aurora5.6"` | no |
+| enabled | Whether the database resources should be created | string | `"true"` | no |
+| engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | string | `"aurora"` | no |
+| engine-version | Aurora database engine version. | string | `"5.6.10a"` | no |
+| envname | Environment name (eg,test, stage or prod) | string | n/a | yes |
+| envtype | Environment type (eg,prod or nonprod) | string | n/a | yes |
+| final\_snapshot\_identifier | The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | string | `"final"` | no |
+| iam\_database\_authentication\_enabled | Whether to enable IAM database authentication for the RDS Cluster | string | `"false"` | no |
+| identifier\_prefix | Prefix for cluster and instance identifier | string | `""` | no |
+| instance\_type | Instance type to use | string | `"db.t2.small"` | no |
+| monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | string | `"0"` | no |
+| name | Name given to DB subnet group | string | n/a | yes |
+| password | Master DB password | string | n/a | yes |
+| performance\_insights\_enabled | Whether to enable Performance Insights | string | `"false"` | no |
+| port | The port on which to accept connections | string | `"3306"` | no |
+| preferred\_backup\_window | When to perform DB backups | string | `"02:00-03:00"` | no |
+| preferred\_maintenance\_window | When to perform DB maintenance | string | `"sun:05:00-sun:06:00"` | no |
+| publicly\_accessible | Whether the DB should have a public IP address | string | `"false"` | no |
+| replica\_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | string | `"0"` | no |
+| replica\_scale\_cpu | CPU usage to trigger autoscaling at | string | `"70"` | no |
+| replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | string | `"false"` | no |
+| replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | string | `"300"` | no |
+| replica\_scale\_max | Maximum number of replicas to allow scaling for | string | `"0"` | no |
+| replica\_scale\_min | Maximum number of replicas to allow scaling for | string | `"2"` | no |
+| replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | string | `"300"` | no |
+| security\_groups | VPC Security Group IDs | list(string) | n/a | yes |
+| skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | string | `"false"` | no |
+| snapshot\_identifier | DB snapshot to create this database from | string | `""` | no |
+| storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | string | `"true"` | no |
+| subnets | List of subnet IDs to use | list(string) | n/a | yes |
+| username | Master DB username | string | `"root"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| all_instance_endpoints_list | Comma separated list of all DB instance endpoints running in cluster |
-| cluster_endpoint | The 'writer' endpoint for the cluster |
-| cluster_identifier | The ID of the RDS Cluster |
-| reader_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
+| all\_instance\_endpoints\_list | Comma separated list of all DB instance endpoints running in cluster |
+| cluster\_endpoint | The 'writer' endpoint for the cluster |
+| cluster\_identifier | The ID of the RDS Cluster |
+| reader\_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,99 +1,100 @@
 resource "aws_cloudwatch_metric_alarm" "alarm_rds_DatabaseConnections_writer" {
-  count               = "${var.enabled && var.cw_alarms ? 1 : 0}"
-  alarm_name          = "${aws_rds_cluster.default.id}-alarm-rds-writer-DatabaseConnections"
+  count               = var.enabled && var.cw_alarms ? 1 : 0
+  alarm_name          = "${aws_rds_cluster.default[0].id}-alarm-rds-writer-DatabaseConnections"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.cw_eval_period_connections}"
+  evaluation_periods  = var.cw_eval_period_connections
   metric_name         = "DatabaseConnections"
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Sum"
-  threshold           = "${var.cw_max_conns}"
-  alarm_description   = "RDS Maximum connection Alarm for ${aws_rds_cluster.default.id} writer"
-  alarm_actions       = ["${var.cw_sns_topic}"]
-  ok_actions          = ["${var.cw_sns_topic}"]
+  threshold           = var.cw_max_conns
+  alarm_description   = "RDS Maximum connection Alarm for ${aws_rds_cluster.default[0].id} writer"
+  alarm_actions       = [var.cw_sns_topic]
+  ok_actions          = [var.cw_sns_topic]
 
-  dimensions {
-    DBClusterIdentifier = "${aws_rds_cluster.default.id}"
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.default[0].id
     Role                = "WRITER"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_rds_DatabaseConnections_reader" {
-  count               = "${var.enabled && var.cw_alarms && var.replica_count > 0 ? 1 : 0}"
-  alarm_name          = "${aws_rds_cluster.default.id}-alarm-rds-reader-DatabaseConnections"
+  count               = var.enabled && var.cw_alarms && var.replica_count > 0 ? 1 : 0
+  alarm_name          = "${aws_rds_cluster.default[0].id}-alarm-rds-reader-DatabaseConnections"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.cw_eval_period_connections}"
+  evaluation_periods  = var.cw_eval_period_connections
   metric_name         = "DatabaseConnections"
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "${var.cw_max_conns}"
-  alarm_description   = "RDS Maximum connection Alarm for ${aws_rds_cluster.default.id} reader(s)"
-  alarm_actions       = ["${var.cw_sns_topic}"]
-  ok_actions          = ["${var.cw_sns_topic}"]
+  threshold           = var.cw_max_conns
+  alarm_description   = "RDS Maximum connection Alarm for ${aws_rds_cluster.default[0].id} reader(s)"
+  alarm_actions       = [var.cw_sns_topic]
+  ok_actions          = [var.cw_sns_topic]
 
-  dimensions {
-    DBClusterIdentifier = "${aws_rds_cluster.default.id}"
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.default[0].id
     Role                = "READER"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_rds_CPU_writer" {
-  count               = "${var.enabled && var.cw_alarms ? 1 : 0}"
-  alarm_name          = "${aws_rds_cluster.default.id}-alarm-rds-writer-CPU"
+  count               = var.enabled && var.cw_alarms ? 1 : 0
+  alarm_name          = "${aws_rds_cluster.default[0].id}-alarm-rds-writer-CPU"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.cw_eval_period_cpu}"
+  evaluation_periods  = var.cw_eval_period_cpu
   metric_name         = "CPUUtilization"
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "${var.cw_max_cpu}"
-  alarm_description   = "RDS CPU Alarm for ${aws_rds_cluster.default.id} writer"
-  alarm_actions       = ["${var.cw_sns_topic}"]
-  ok_actions          = ["${var.cw_sns_topic}"]
+  threshold           = var.cw_max_cpu
+  alarm_description   = "RDS CPU Alarm for ${aws_rds_cluster.default[0].id} writer"
+  alarm_actions       = [var.cw_sns_topic]
+  ok_actions          = [var.cw_sns_topic]
 
-  dimensions {
-    DBClusterIdentifier = "${aws_rds_cluster.default.id}"
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.default[0].id
     Role                = "WRITER"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_rds_CPU_reader" {
-  count               = "${var.enabled && var.cw_alarms && var.replica_count > 0 ? 1 : 0}"
-  alarm_name          = "${aws_rds_cluster.default.id}-alarm-rds-reader-CPU"
+  count               = var.enabled && var.cw_alarms && var.replica_count > 0 ? 1 : 0
+  alarm_name          = "${aws_rds_cluster.default[0].id}-alarm-rds-reader-CPU"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.cw_eval_period_cpu}"
+  evaluation_periods  = var.cw_eval_period_cpu
   metric_name         = "CPUUtilization"
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "${var.cw_max_cpu}"
-  alarm_description   = "RDS CPU Alarm for ${aws_rds_cluster.default.id} reader(s)"
-  alarm_actions       = ["${var.cw_sns_topic}"]
-  ok_actions          = ["${var.cw_sns_topic}"]
+  threshold           = var.cw_max_cpu
+  alarm_description   = "RDS CPU Alarm for ${aws_rds_cluster.default[0].id} reader(s)"
+  alarm_actions       = [var.cw_sns_topic]
+  ok_actions          = [var.cw_sns_topic]
 
-  dimensions {
-    DBClusterIdentifier = "${aws_rds_cluster.default.id}"
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.default[0].id
     Role                = "READER"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_rds_replica_lag" {
-  count               = "${var.enabled && var.cw_alarms && var.replica_count > 0 ? 1 : 0}"
-  alarm_name          = "${aws_rds_cluster.default.id}-alarm-rds-reader-AuroraReplicaLag"
+  count               = var.enabled && var.cw_alarms && var.replica_count > 0 ? 1 : 0
+  alarm_name          = "${aws_rds_cluster.default[0].id}-alarm-rds-reader-AuroraReplicaLag"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.cw_eval_period_replica_lag}"
+  evaluation_periods  = var.cw_eval_period_replica_lag
   metric_name         = "AuroraReplicaLag"
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "${var.cw_max_replica_lag}"
-  alarm_description   = "RDS CPU Alarm for ${aws_rds_cluster.default.id}"
-  alarm_actions       = ["${var.cw_sns_topic}"]
-  ok_actions          = ["${var.cw_sns_topic}"]
+  threshold           = var.cw_max_replica_lag
+  alarm_description   = "RDS CPU Alarm for ${aws_rds_cluster.default[0].id}"
+  alarm_actions       = [var.cw_sns_topic]
+  ok_actions          = [var.cw_sns_topic]
 
-  dimensions {
-    DBClusterIdentifier = "${aws_rds_cluster.default.id}"
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.default[0].id
     Role                = "READER"
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -1,263 +1,99 @@
-/**
-  * # tf-aws-aurora
-  *
-  * AWS Aurora DB Cluster & Instance(s) Terraform Module.
-  *
-  * Gives you:
-  *
-  *  - A DB subnet group
-  *  - An Aurora DB cluster
-  *  - An Aurora DB instance + 'n' number of additional instances
-  *  - Optionally RDS 'Enhanced Monitoring' + associated required IAM role/policy (by simply setting the `monitoring_interval` param to > `0`
-  *  - Optionally sensible alarms to SNS (high CPU, high connections, slow replication)
-  *  - Optionally configure autoscaling for read replicas (MySQL clusters only)
-  *
-  * ## Contributing
-  *
-  * Ensure any variables you add have a type and a description.
-  * This README is generated with [terraform-docs](https://github.com/segmentio/terraform-docs):
-  *
-  * `terraform-docs md . > README.md`
-  *
-  * ## Usage examples
-  *
-  * *It is recommended you always create a parameter group, even if it exactly matches the defaults.*
-  * Changing the parameter group in use requires a restart of the DB cluster, modifying parameters within a group
-  * may not (depending on the parameter being altered)
-  *
-  * ## Known issues
-  * AWS doesn't automatically remove RDS instances created from autoscaling when you remove the autoscaling rules and this can cause issues when using Terraform to destroy the cluster.  To work around this, you should make sure there are no automatically created RDS instances running before attempting to destroy a cluster.
-  *
-  * ### Aurora 1.x (MySQL 5.6)
-  *
-  * 
-  * resource "aws_sns_topic" "db_alarms_56" {
-  *   name = "aurora-db-alarms-56"
-  * }
-  * 
-  * module "aurora_db_56" {
-  *   source                          = "../.."
-  *   name                            = "test-aurora-db-56"
-  *   envname                         = "test56"
-  *   envtype                         = "test"
-  *   subnets                         = ["${module.vpc.private_subnets}"]
-  *   azs                             = ["${module.vpc.availability_zones}"]
-  *   replica_count                   = "1"
-  *   security_groups                 = ["${aws_security_group.allow_all.id}"]
-  *   instance_type                   = "db.t2.medium"
-  *   username                        = "root"
-  *   password                        = "changeme"
-  *   backup_retention_period         = "5"
-  *   final_snapshot_identifier       = "final-db-snapshot-prod"
-  *   storage_encrypted               = "true"
-  *   apply_immediately               = "true"
-  *   monitoring_interval             = "10"
-  *   cw_alarms                       = true
-  *   cw_sns_topic                    = "${aws_sns_topic.db_alarms_56.id}"
-  *   db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_56_parameter_group.id}"
-  *   db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_cluster_56_parameter_group.id}"
-  * }
-  * 
-  * resource "aws_db_parameter_group" "aurora_db_56_parameter_group" {
-  *   name        = "test-aurora-db-56-parameter-group"
-  *   family      = "aurora5.6"
-  *   description = "test-aurora-db-56-parameter-group"
-  * }
-  * 
-  * resource "aws_rds_cluster_parameter_group" "aurora_cluster_56_parameter_group" {
-  *   name        = "test-aurora-56-cluster-parameter-group"
-  *   family      = "aurora5.6"
-  *   description = "test-aurora-56-cluster-parameter-group"
-  * }
-  *
-  * ### Aurora 2.x (MySQL 5.7)
-  *
-  * ```hcl
-  * resource "aws_sns_topic" "db_alarms" {
-  *   name = "aurora-db-alarms"
-  * }
-  * 
-  * module "aurora_db_57" {
-  *   source                          = "../.."
-  *   engine                          = "aurora-mysql"
-  *   engine-version                  = "5.7.12"
-  *   name                            = "test-aurora-db-57"
-  *   envname                         = "test-57"
-  *   envtype                         = "test"
-  *   subnets                         = ["${module.vpc.private_subnets}"]
-  *   azs                             = ["${module.vpc.availability_zones}"]
-  *   replica_count                   = "1"
-  *   security_groups                 = ["${aws_security_group.allow_all.id}"]
-  *   instance_type                   = "db.t2.medium"
-  *   username                        = "root"
-  *   password                        = "changeme"
-  *   backup_retention_period         = "5"
-  *   final_snapshot_identifier       = "final-db-snapshot-prod"
-  *   storage_encrypted               = "true"
-  *   apply_immediately               = "true"
-  *   monitoring_interval             = "10"
-  *   cw_alarms                       = true
-  *   cw_sns_topic                    = "${aws_sns_topic.db_alarms.id}"
-  *   db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_57_parameter_group.id}"
-  *   db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id}"
-  * }
-  * 
-  * resource "aws_db_parameter_group" "aurora_db_57_parameter_group" {
-  *   name        = "test-aurora-db-57-parameter-group"
-  *   family      = "aurora-mysql5.7"
-  *   description = "test-aurora-db-57-parameter-group"
-  * }
-  * 
-  * resource "aws_rds_cluster_parameter_group" "aurora_57_cluster_parameter_group" {
-  *   name        = "test-aurora-57-cluster-parameter-group"
-  *   family      = "aurora-mysql5.7"
-  *   description = "test-aurora-57-cluster-parameter-group"
-  * }
-  * ```
-  ### Aurora PostgreSQL
-  *
-  * ```hcl
-  * resource "aws_sns_topic" "db_alarms_postgres96" {
-  *   name = "aurora-db-alarms-postgres96"
-  * }
-  *
-  * module "aurora_db_postgres96" {
-  *   source                          = "../.."
-  *   engine                          = "aurora-postgresql"
-  *   engine-version                  = "9.6.3"
-  *   name                            = "test-aurora-db-postgres96"
-  *   envname                         = "test-pg96"
-  *   envtype                         = "test"
-  *   subnets                         = ["${module.vpc.private_subnets}"]
-  *   azs                             = ["${module.vpc.availability_zones}"]
-  *   replica_count                   = "1"
-  *   security_groups                 = ["${aws_security_group.allow_all.id}"]
-  *   instance_type                   = "db.r4.large"
-  *   username                        = "root"
-  *   password                        = "changeme"
-  *   backup_retention_period         = "5"
-  *   final_snapshot_identifier       = "final-db-snapshot-prod"
-  *   storage_encrypted               = "true"
-  *   apply_immediately               = "true"
-  *   monitoring_interval             = "10"
-  *   cw_alarms                       = true
-  *   cw_sns_topic                    = "${aws_sns_topic.db_alarms_postgres96.id}"
-  *   db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_postgres96_parameter_group.id}"
-  *   db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id}"
-  * }
-  *
-  * resource "aws_db_parameter_group" "aurora_db_postgres96_parameter_group" {
-  *   name        = "test-aurora-db-postgres96-parameter-group"
-  *   family      = "aurora-postgresql9.6"
-  *   description = "test-aurora-db-postgres96-parameter-group"
-  * }
-  *
-  * resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres96_parameter_group" {
-  *   name        = "test-aurora-postgres96-cluster-parameter-group"
-  *   family      = "aurora-postgresql9.6"
-  *   description = "test-aurora-postgres96-cluster-parameter-group"
-  * }
-  * ```
-  */
-
 // DB Subnet Group creation
 resource "aws_db_subnet_group" "main" {
-  count       = "${var.enabled ? 1 : 0}"
-  name        = "${var.name}"
+  count       = var.enabled ? 1 : 0
+  name        = var.name
   description = "Group of DB subnets"
-  subnet_ids  = ["${var.subnets}"]
+  subnet_ids  = var.subnets
 
-  tags {
-    envname = "${var.envname}"
-    envtype = "${var.envtype}"
+  tags = {
+    envname = var.envname
+    envtype = var.envtype
   }
 }
 
 // Create single DB instance
 resource "aws_rds_cluster_instance" "cluster_instance_0" {
-  count      = "${var.enabled ? 1 : 0}"
-  depends_on = [
-    "aws_iam_role_policy_attachment.rds-enhanced-monitoring-policy-attach",
-  ]
+  count      = var.enabled ? 1 : 0
+  depends_on = [aws_iam_role_policy_attachment.rds-enhanced-monitoring-policy-attach]
 
-  identifier                   = "${var.identifier_prefix != "" ? format("%s-node-0", var.identifier_prefix) : format("%s-aurora-node-0", var.envname)}"
-  cluster_identifier           = "${aws_rds_cluster.default.id}"
-  engine                       = "${var.engine}"
-  engine_version               = "${var.engine-version}"
-  instance_class               = "${var.instance_type}"
-  publicly_accessible          = "${var.publicly_accessible}"
-  db_subnet_group_name         = "${aws_db_subnet_group.main.name}"
-  db_parameter_group_name      = "${var.db_parameter_group_name}"
-  preferred_maintenance_window = "${var.preferred_maintenance_window}"
-  apply_immediately            = "${var.apply_immediately}"
-  monitoring_role_arn          = "${join("", aws_iam_role.rds-enhanced-monitoring.*.arn)}"
-  monitoring_interval          = "${var.monitoring_interval}"
-  auto_minor_version_upgrade   = "${var.auto_minor_version_upgrade}"
+  identifier                   = var.identifier_prefix != "" ? format("%s-node-0", var.identifier_prefix) : format("%s-aurora-node-0", var.envname)
+  cluster_identifier           = aws_rds_cluster.default[0].id
+  engine                       = var.engine
+  engine_version               = var.engine-version
+  instance_class               = var.instance_type
+  publicly_accessible          = var.publicly_accessible
+  db_subnet_group_name         = aws_db_subnet_group.main[0].name
+  db_parameter_group_name      = var.db_parameter_group_name
+  preferred_maintenance_window = var.preferred_maintenance_window
+  apply_immediately            = var.apply_immediately
+  monitoring_role_arn          = join("", aws_iam_role.rds-enhanced-monitoring.*.arn)
+  monitoring_interval          = var.monitoring_interval
+  auto_minor_version_upgrade   = var.auto_minor_version_upgrade
   promotion_tier               = "0"
-  performance_insights_enabled = "${var.performance_insights_enabled}"
+  performance_insights_enabled = var.performance_insights_enabled
 
-  tags {
-    envname = "${var.envname}"
-    envtype = "${var.envtype}"
+  tags = {
+    envname = var.envname
+    envtype = var.envtype
   }
 }
 
 // Create 'n' number of additional DB instance(s) in same cluster
 resource "aws_rds_cluster_instance" "cluster_instance_n" {
-  depends_on                   = ["aws_rds_cluster_instance.cluster_instance_0"]
-  count                        = "${var.enabled ? var.replica_scale_enabled ? var.replica_scale_min : var.replica_count : 0}"
-  engine                       = "${var.engine}"
-  engine_version               = "${var.engine-version}"
-  identifier                   = "${var.identifier_prefix != "" ? format("%s-node-%d", var.identifier_prefix, count.index + 1) : format("%s-aurora-node-%d", var.envname, count.index + 1)}"
-  cluster_identifier           = "${aws_rds_cluster.default.id}"
-  instance_class               = "${var.instance_type}"
-  publicly_accessible          = "${var.publicly_accessible}"
-  db_subnet_group_name         = "${aws_db_subnet_group.main.name}"
-  db_parameter_group_name      = "${var.db_parameter_group_name}"
-  preferred_maintenance_window = "${var.preferred_maintenance_window}"
-  apply_immediately            = "${var.apply_immediately}"
-  monitoring_role_arn          = "${join("", aws_iam_role.rds-enhanced-monitoring.*.arn)}"
-  monitoring_interval          = "${var.monitoring_interval}"
-  auto_minor_version_upgrade   = "${var.auto_minor_version_upgrade}"
-  promotion_tier               = "${count.index + 1}"
-  performance_insights_enabled = "${var.performance_insights_enabled}"
+  depends_on                   = [aws_rds_cluster_instance.cluster_instance_0]
+  count                        = var.enabled ? var.replica_scale_enabled ? var.replica_scale_min : var.replica_count : 0
+  engine                       = var.engine
+  engine_version               = var.engine-version
+  identifier                   = var.identifier_prefix != "" ? format("%s-node-%d", var.identifier_prefix, count.index + 1) : format("%s-aurora-node-%d", var.envname, count.index + 1)
+  cluster_identifier           = aws_rds_cluster.default[0].id
+  instance_class               = var.instance_type
+  publicly_accessible          = var.publicly_accessible
+  db_subnet_group_name         = aws_db_subnet_group.main[0].name
+  db_parameter_group_name      = var.db_parameter_group_name
+  preferred_maintenance_window = var.preferred_maintenance_window
+  apply_immediately            = var.apply_immediately
+  monitoring_role_arn          = join("", aws_iam_role.rds-enhanced-monitoring.*.arn)
+  monitoring_interval          = var.monitoring_interval
+  auto_minor_version_upgrade   = var.auto_minor_version_upgrade
+  promotion_tier               = count.index + 1
+  performance_insights_enabled = var.performance_insights_enabled
 
-  tags {
-    envname = "${var.envname}"
-    envtype = "${var.envtype}"
+  tags = {
+    envname = var.envname
+    envtype = var.envtype
   }
 }
 
 // Create DB Cluster
 resource "aws_rds_cluster" "default" {
-  count              = "${var.enabled ? 1 : 0}"
-  cluster_identifier = "${var.identifier_prefix != "" ? format("%s-cluster", var.identifier_prefix) : format("%s-aurora-cluster", var.envname)}"
-  availability_zones = ["${var.azs}"]
-  engine             = "${var.engine}"
+  count              = var.enabled ? 1 : 0
+  cluster_identifier = var.identifier_prefix != "" ? format("%s-cluster", var.identifier_prefix) : format("%s-aurora-cluster", var.envname)
+  availability_zones = var.azs
+  engine             = var.engine
 
-  engine_version                      = "${var.engine-version}"
-  master_username                     = "${var.username}"
-  master_password                     = "${var.password}"
-  final_snapshot_identifier           = "${var.final_snapshot_identifier}-${random_id.server.hex}"
-  skip_final_snapshot                 = "${var.skip_final_snapshot}"
-  backup_retention_period             = "${var.backup_retention_period}"
-  preferred_backup_window             = "${var.preferred_backup_window}"
-  preferred_maintenance_window        = "${var.preferred_maintenance_window}"
-  port                                = "${var.port}"
-  db_subnet_group_name                = "${aws_db_subnet_group.main.name}"
-  vpc_security_group_ids              = ["${var.security_groups}"]
-  snapshot_identifier                 = "${var.snapshot_identifier}"
-  storage_encrypted                   = "${var.storage_encrypted}"
-  apply_immediately                   = "${var.apply_immediately}"
-  db_cluster_parameter_group_name     = "${var.db_cluster_parameter_group_name}"
-  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
+  engine_version                      = var.engine-version
+  master_username                     = var.username
+  master_password                     = var.password
+  final_snapshot_identifier           = "${var.final_snapshot_identifier}-${random_id.server[0].hex}"
+  skip_final_snapshot                 = var.skip_final_snapshot
+  backup_retention_period             = var.backup_retention_period
+  preferred_backup_window             = var.preferred_backup_window
+  preferred_maintenance_window        = var.preferred_maintenance_window
+  port                                = var.port
+  db_subnet_group_name                = aws_db_subnet_group.main[0].name
+  vpc_security_group_ids              = var.security_groups
+  snapshot_identifier                 = var.snapshot_identifier
+  storage_encrypted                   = var.storage_encrypted
+  apply_immediately                   = var.apply_immediately
+  db_cluster_parameter_group_name     = var.db_cluster_parameter_group_name
+  iam_database_authentication_enabled = var.iam_database_authentication_enabled
 }
 
 // Geneate an ID when an environment is initialised
 resource "random_id" "server" {
-  count   = "${var.enabled ? 1 : 0}"
+  count = var.enabled ? 1 : 0
   keepers = {
-    id = "${aws_db_subnet_group.main.name}"
+    id = aws_db_subnet_group.main[0].name
   }
 
   byte_length = 8
@@ -265,7 +101,7 @@ resource "random_id" "server" {
 
 // IAM Role + Policy attach for Enhanced Monitoring
 data "aws_iam_policy_document" "monitoring-rds-assume-role-policy" {
-  count = "${var.enabled ? 1 : 0}"
+  count = var.enabled ? 1 : 0
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -277,33 +113,33 @@ data "aws_iam_policy_document" "monitoring-rds-assume-role-policy" {
 }
 
 resource "aws_iam_role" "rds-enhanced-monitoring" {
-  count              = "${var.enabled && var.monitoring_interval > 0 ? 1 : 0}"
+  count              = var.enabled && var.monitoring_interval > 0 ? 1 : 0
   name_prefix        = "rds-enhanced-mon-${var.envname}-"
-  assume_role_policy = "${data.aws_iam_policy_document.monitoring-rds-assume-role-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.monitoring-rds-assume-role-policy[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "rds-enhanced-monitoring-policy-attach" {
-  count      = "${var.enabled && var.monitoring_interval > 0 ? 1 : 0}"
-  role       = "${aws_iam_role.rds-enhanced-monitoring.name}"
+  count      = var.enabled && var.monitoring_interval > 0 ? 1 : 0
+  role       = aws_iam_role.rds-enhanced-monitoring[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 
 // Autoscaling
 resource "aws_appautoscaling_target" "autoscaling" {
-  count              = "${var.enabled && var.replica_scale_enabled ? 1 : 0}"
-  max_capacity       = "${var.replica_scale_max}"
-  min_capacity       = "${var.replica_scale_min}"
-  resource_id        = "cluster:${aws_rds_cluster.default.cluster_identifier}"
+  count              = var.enabled && var.replica_scale_enabled ? 1 : 0
+  max_capacity       = var.replica_scale_max
+  min_capacity       = var.replica_scale_min
+  resource_id        = "cluster:${aws_rds_cluster.default[0].cluster_identifier}"
   scalable_dimension = "rds:cluster:ReadReplicaCount"
   service_namespace  = "rds"
 }
 
 resource "aws_appautoscaling_policy" "autoscaling" {
-  count              = "${var.enabled && var.replica_scale_enabled ? 1 : 0}"
-  depends_on         = ["aws_appautoscaling_target.autoscaling"]
+  count              = var.enabled && var.replica_scale_enabled ? 1 : 0
+  depends_on         = [aws_appautoscaling_target.autoscaling]
   name               = "target-metric"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = "cluster:${aws_rds_cluster.default.cluster_identifier}"
+  resource_id        = "cluster:${aws_rds_cluster.default[0].cluster_identifier}"
   scalable_dimension = "rds:cluster:ReadReplicaCount"
   service_namespace  = "rds"
 
@@ -312,8 +148,8 @@ resource "aws_appautoscaling_policy" "autoscaling" {
       predefined_metric_type = "RDSReaderAverageCPUUtilization"
     }
 
-    scale_in_cooldown  = "${var.replica_scale_in_cooldown}"
-    scale_out_cooldown = "${var.replica_scale_out_cooldown}"
-    target_value       = "${var.replica_scale_cpu}"
+    scale_in_cooldown  = var.replica_scale_in_cooldown
+    scale_out_cooldown = var.replica_scale_out_cooldown
+    target_value       = var.replica_scale_cpu
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,23 @@
 // The 'writer' endpoint for the cluster
 output "cluster_endpoint" {
-  value = "${join("", aws_rds_cluster.default.*.endpoint)}"
+  value = join("", aws_rds_cluster.default.*.endpoint)
 }
 
 // Comma separated list of all DB instance endpoints running in cluster
 output "all_instance_endpoints_list" {
-  value = ["${concat(aws_rds_cluster_instance.cluster_instance_0.*.endpoint, aws_rds_cluster_instance.cluster_instance_n.*.endpoint)}"]
+  value = [concat(
+    aws_rds_cluster_instance.cluster_instance_0.*.endpoint,
+    aws_rds_cluster_instance.cluster_instance_n.*.endpoint,
+  )]
 }
 
 // A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas
 output "reader_endpoint" {
-  value = "${join("", aws_rds_cluster.default.*.reader_endpoint)}"
+  value = join("", aws_rds_cluster.default.*.reader_endpoint)
 }
 
 // The ID of the RDS Cluster
 output "cluster_identifier" {
-  value = "${join("", aws_rds_cluster.default.*.id)}"
+  value = join("", aws_rds_cluster.default.*.id)
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "cluster_endpoint" {
   value = join("", aws_rds_cluster.default.*.endpoint)
 }
 
-// Comma separated list of all DB instance endpoints running in cluster
+// List of all DB instance endpoints running in cluster
 output "all_instance_endpoints_list" {
   value = [concat(
     aws_rds_cluster_instance.cluster_instance_0.*.endpoint,

--- a/tests/terraform/test-mysql-56.tf
+++ b/tests/terraform/test-mysql-56.tf
@@ -7,10 +7,10 @@ module "aurora_db_56" {
   name                                = "test-aurora-db-56"
   envname                             = "test56"
   envtype                             = "test"
-  subnets                             = ["${module.vpc.private_subnets}"]
-  azs                                 = ["${module.vpc.availability_zones}"]
+  subnets                             = module.vpc.private_subnet_ids
+  azs                                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   replica_count                       = "1"
-  security_groups                     = ["${aws_security_group.allow_all.id}"]
+  security_groups                     = [aws_security_group.allow_all.id]
   instance_type                       = "db.t2.medium"
   username                            = "root"
   password                            = "changeme"
@@ -20,9 +20,9 @@ module "aurora_db_56" {
   apply_immediately                   = "true"
   monitoring_interval                 = "10"
   cw_alarms                           = true
-  cw_sns_topic                        = "${aws_sns_topic.db_alarms_56.id}"
-  db_parameter_group_name             = "${aws_db_parameter_group.aurora_db_56_parameter_group.id}"
-  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.aurora_cluster_56_parameter_group.id}"
+  cw_sns_topic                        = aws_sns_topic.db_alarms_56.id
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_56_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_cluster_56_parameter_group.id
   iam_database_authentication_enabled = "true"
 }
 
@@ -37,3 +37,4 @@ resource "aws_rds_cluster_parameter_group" "aurora_cluster_56_parameter_group" {
   family      = "aurora5.6"
   description = "test-aurora-56-cluster-parameter-group"
 }
+

--- a/tests/terraform/test-mysql-57-autoscaling.tf
+++ b/tests/terraform/test-mysql-57-autoscaling.tf
@@ -9,9 +9,9 @@ module "aurora_db_57_autoscaling" {
   name                                = "aurora-my57-asg"
   envname                             = "test-57-asg"
   envtype                             = "test"
-  subnets                             = ["${module.vpc.private_subnets}"]
-  azs                                 = ["${module.vpc.availability_zones}"]
-  security_groups                     = ["${aws_security_group.allow_all.id}"]
+  subnets                             = module.vpc.private_subnet_ids
+  azs                                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  security_groups                     = [aws_security_group.allow_all.id]
   instance_type                       = "db.t2.medium"
   username                            = "root"
   password                            = "changeme"
@@ -21,9 +21,9 @@ module "aurora_db_57_autoscaling" {
   apply_immediately                   = "true"
   monitoring_interval                 = "10"
   cw_alarms                           = true
-  cw_sns_topic                        = "${aws_sns_topic.db_alarms_57_autoscaling.id}"
-  db_parameter_group_name             = "${aws_db_parameter_group.aurora_db_57_autoscaling_parameter_group.id}"
-  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.aurora_57_autoscaling_cluster_parameter_group.id}"
+  cw_sns_topic                        = aws_sns_topic.db_alarms_57_autoscaling.id
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_57_autoscaling_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_57_autoscaling_cluster_parameter_group.id
   replica_scale_enabled               = true
   replica_scale_min                   = "1"
   replica_scale_max                   = "1"
@@ -44,3 +44,4 @@ resource "aws_rds_cluster_parameter_group" "aurora_57_autoscaling_cluster_parame
   family      = "aurora-mysql5.7"
   description = "test-aurora-57-autoscaling-cluster-parameter-group"
 }
+

--- a/tests/terraform/test-mysql-57.tf
+++ b/tests/terraform/test-mysql-57.tf
@@ -9,10 +9,10 @@ module "aurora_db_57" {
   name                                = "test-aurora-db-57"
   envname                             = "test-57"
   envtype                             = "test"
-  subnets                             = ["${module.vpc.private_subnets}"]
-  azs                                 = ["${module.vpc.availability_zones}"]
+  subnets                             = module.vpc.private_subnet_ids
+  azs                                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   replica_count                       = "1"
-  security_groups                     = ["${aws_security_group.allow_all.id}"]
+  security_groups                     = [aws_security_group.allow_all.id]
   instance_type                       = "db.t2.medium"
   username                            = "root"
   password                            = "changeme"
@@ -22,9 +22,9 @@ module "aurora_db_57" {
   apply_immediately                   = "true"
   monitoring_interval                 = "10"
   cw_alarms                           = true
-  cw_sns_topic                        = "${aws_sns_topic.db_alarms.id}"
-  db_parameter_group_name             = "${aws_db_parameter_group.aurora_db_57_parameter_group.id}"
-  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id}"
+  cw_sns_topic                        = aws_sns_topic.db_alarms.id
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_57_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id
   iam_database_authentication_enabled = "true"
 }
 
@@ -39,3 +39,4 @@ resource "aws_rds_cluster_parameter_group" "aurora_57_cluster_parameter_group" {
   family      = "aurora-mysql5.7"
   description = "test-aurora-57-cluster-parameter-group"
 }
+

--- a/tests/terraform/test-postgres.tf
+++ b/tests/terraform/test-postgres.tf
@@ -9,10 +9,10 @@ module "aurora_db_postgres96" {
   name                                = "test-aurora-db-postgres96"
   envname                             = "test-pg96"
   envtype                             = "test"
-  subnets                             = ["${module.vpc.private_subnets}"]
-  azs                                 = ["${module.vpc.availability_zones}"]
+  subnets                             = module.vpc.private_subnet_ids
+  azs                                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   replica_count                       = "1"
-  security_groups                     = ["${aws_security_group.allow_all.id}"]
+  security_groups                     = [aws_security_group.allow_all.id]
   instance_type                       = "db.r4.large"
   username                            = "root"
   password                            = "changeme"
@@ -22,9 +22,9 @@ module "aurora_db_postgres96" {
   apply_immediately                   = "true"
   monitoring_interval                 = "10"
   cw_alarms                           = true
-  cw_sns_topic                        = "${aws_sns_topic.db_alarms_postgres96.id}"
-  db_parameter_group_name             = "${aws_db_parameter_group.aurora_db_postgres96_parameter_group.id}"
-  db_cluster_parameter_group_name     = "${aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id}"
+  cw_sns_topic                        = aws_sns_topic.db_alarms_postgres96.id
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_postgres96_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id
   iam_database_authentication_enabled = "false"
 }
 
@@ -39,3 +39,4 @@ resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres96_parameter_
   family      = "aurora-postgresql9.6"
   description = "test-aurora-postgres96-cluster-parameter-group"
 }
+

--- a/tests/terraform/versions.tf
+++ b/tests/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/tests/terraform/vpc.tf
+++ b/tests/terraform/vpc.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "allow_all" {
   name        = "allow_all"
   description = "Allow all HTTP/HTTPS traffic"
-  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_id      = module.vpc.vpc_id
 
   ingress {
     from_port   = 0
@@ -26,22 +26,19 @@ resource "aws_security_group" "allow_all" {
 }
 
 module "vpc" {
-  source               = "git::ssh://git@gogs.bashton.net/Bashton-Terraform-Modules/tf-aws-vpc-natgw.git"
-  name                 = "test-aurora"
-  ipv4_cidr            = "10.0.0.0/16"
-  public_ipv4_subnets  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  private_ipv4_subnets = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
-  azs                  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-}
+  source  = "claranet/vpc-modules/aws"
+  version = "1.0.0"
 
-output "vpc_id" {
-  value = "${module.vpc.vpc_id}"
-}
+  enable_dns_support   = true
+  enable_dns_hostnames = true
 
-output "vpc_private_subnet_ids" {
-  value = ["${module.vpc.private_subnets}"]
-}
+  availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
 
-output "vpc_public_subnet_ids" {
-  value = ["${module.vpc.public_subnets}"]
+  vpc_cidr_block = "10.112.0.0/16"
+
+  public_cidr_block   = "10.112.0.0/20"
+  public_subnet_count = 3
+
+  private_cidr_block   = "10.112.16.0/20"
+  private_subnet_count = 3
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,53 +1,53 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name given to DB subnet group"
 }
 
 variable "subnets" {
-  type        = "list"
+  type        = list(string)
   description = "List of subnet IDs to use"
 }
 
 variable "envname" {
-  type        = "string"
+  type        = string
   description = "Environment name (eg,test, stage or prod)"
 }
 
 variable "envtype" {
-  type        = "string"
+  type        = string
   description = "Environment type (eg,prod or nonprod)"
 }
 
 variable "identifier_prefix" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Prefix for cluster and instance identifier"
 }
 
 variable "azs" {
-  type        = "list"
+  type        = list(string)
   description = "List of AZs to use"
 }
 
 variable "replica_count" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead."
 }
 
 variable "security_groups" {
-  type        = "list"
+  type        = list(string)
   description = "VPC Security Group IDs"
 }
 
 variable "instance_type" {
-  type        = "string"
+  type        = string
   default     = "db.t2.small"
   description = "Instance type to use"
 }
 
 variable "publicly_accessible" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Whether the DB should have a public IP address"
 }
@@ -58,198 +58,199 @@ variable "username" {
 }
 
 variable "password" {
-  type        = "string"
+  type        = string
   description = "Master DB password"
 }
 
 variable "final_snapshot_identifier" {
-  type        = "string"
+  type        = string
   default     = "final"
   description = "The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too."
 }
 
 variable "skip_final_snapshot" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Should a final snapshot be created on cluster destroy"
 }
 
 variable "backup_retention_period" {
-  type        = "string"
+  type        = string
   default     = "7"
   description = "How long to keep backups for (in days)"
 }
 
 variable "preferred_backup_window" {
-  type        = "string"
+  type        = string
   default     = "02:00-03:00"
   description = "When to perform DB backups"
 }
 
 variable "preferred_maintenance_window" {
-  type        = "string"
+  type        = string
   default     = "sun:05:00-sun:06:00"
   description = "When to perform DB maintenance"
 }
 
 variable "port" {
-  type        = "string"
+  type        = string
   default     = "3306"
   description = "The port on which to accept connections"
 }
 
 variable "apply_immediately" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Determines whether or not any DB modifications are applied immediately, or during the maintenance window"
 }
 
 variable "monitoring_interval" {
-  type        = "string"
+  type        = string
   default     = 0
   description = "The interval (seconds) between points when Enhanced Monitoring metrics are collected"
 }
 
 variable "auto_minor_version_upgrade" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Determines whether minor engine upgrades will be performed automatically in the maintenance window"
 }
 
 variable "db_parameter_group_name" {
-  type        = "string"
+  type        = string
   default     = "default.aurora5.6"
   description = "The name of a DB parameter group to use"
 }
 
 variable "db_cluster_parameter_group_name" {
-  type        = "string"
+  type        = string
   default     = "default.aurora5.6"
   description = "The name of a DB Cluster parameter group to use"
 }
 
 variable "snapshot_identifier" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "DB snapshot to create this database from"
 }
 
 variable "storage_encrypted" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Specifies whether the underlying storage layer should be encrypted"
 }
 
 variable "cw_alarms" {
-  type        = "string"
+  type        = string
   default     = false
   description = "Whether to enable CloudWatch alarms - requires `cw_sns_topic` is specified"
 }
 
 variable "cw_sns_topic" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "An SNS topic to publish CloudWatch alarms to"
 }
 
 variable "cw_max_conns" {
-  type        = "string"
+  type        = string
   default     = "500"
   description = "Connection count beyond which to trigger a CloudWatch alarm"
 }
 
 variable "cw_max_cpu" {
-  type        = "string"
+  type        = string
   default     = "85"
   description = "CPU threshold above which to alarm"
 }
 
 variable "cw_max_replica_lag" {
-  type        = "string"
+  type        = string
   default     = "2000"
   description = "Maximum Aurora replica lag in milliseconds above which to alarm"
 }
 
 variable "cw_eval_period_connections" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Evaluation period for the DB connections alarms"
 }
 
 variable "cw_eval_period_cpu" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "Evaluation period for the DB CPU alarms"
 }
 
 variable "cw_eval_period_replica_lag" {
-  type        = "string"
+  type        = string
   default     = "5"
   description = "Evaluation period for the DB replica lag alarm"
 }
 
 variable "engine" {
-  type        = "string"
+  type        = string
   default     = "aurora"
   description = "Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql"
 }
 
 variable "engine-version" {
-  type        = "string"
+  type        = string
   default     = "5.6.10a"
   description = "Aurora database engine version."
 }
 
 variable "replica_scale_enabled" {
-  type        = "string"
+  type        = string
   default     = false
   description = "Whether to enable autoscaling for RDS Aurora (MySQL) read replicas"
 }
 
 variable "replica_scale_max" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "Maximum number of replicas to allow scaling for"
 }
 
 variable "replica_scale_min" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "Maximum number of replicas to allow scaling for"
 }
 
 variable "replica_scale_cpu" {
-  type        = "string"
+  type        = string
   default     = "70"
   description = "CPU usage to trigger autoscaling at"
 }
 
 variable "replica_scale_in_cooldown" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "Cooldown in seconds before allowing further scaling operations after a scale in"
 }
 
 variable "replica_scale_out_cooldown" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "Cooldown in seconds before allowing further scaling operations after a scale out"
 }
 
 variable "performance_insights_enabled" {
-  type        = "string"
+  type        = string
   default     = false
   description = "Whether to enable Performance Insights"
 }
 
 variable "iam_database_authentication_enabled" {
-  type        = "string"
+  type        = string
   default     = false
   description = "Whether to enable IAM database authentication for the RDS Cluster"
 }
 
 variable "enabled" {
-  type        = "string"
+  type        = string
   default     = true
   description = "Whether the database resources should be created"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Running `terraform 0.12upgrade` seemed to work fine for the module itself

Updated tests to use https://github.com/claranet/terraform-aws-vpc-modules for the VPC side of things

Plan, apply and destroy all went through successfully