### PR TITLE
Use terraform-docs again

### DIFF
--- a/.github/workflows/README.yml
+++ b/.github/workflows/README.yml
@@ -1,0 +1,17 @@
+name: README.md
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker run --rm -v $PWD:/data claranet/terraform-docs:0.8.1 terraform-docs-replace-012 --sort-inputs-by-required --with-aggregate-type-defaults --no-providers md README.md
+      - uses: claranet/git-auto-commit-action@v3.0.0
+        with:
+          file_pattern: README.md
+          commit_message: Update README.md using terraform-docs

--- a/README.md
+++ b/README.md
@@ -11,13 +11,6 @@ Gives you:
  - Optionally sensible alarms to SNS (high CPU, high connections, slow replication)
  - Optionally configure autoscaling for read replicas (MySQL clusters only)
 
-## Contributing
-
-Ensure any variables you add have a type and a description.
-This README is generated with [terraform-docs](https://github.com/segmentio/terraform-docs):
-
-`terraform-docs md . > README.md`
-
 ## Terraform version compatibility
 
 | Module version | Terraform version |
@@ -25,19 +18,21 @@ This README is generated with [terraform-docs](https://github.com/segmentio/terr
 | 4.x.x          | 0.12.x            |
 | 3.x.x          | 0.11.x            |
 
-## Usage examples
-
-*It is recommended you always create a parameter group, even if it exactly matches the defaults.*
-Changing the parameter group in use requires a restart of the DB cluster, modifying parameters within a group
-may not (depending on the parameter being altered)
-
 ## Known issues
+
 AWS doesn't automatically remove RDS instances created from autoscaling when you remove the autoscaling rules and this can cause issues when using Terraform to destroy the cluster.  To work around this, you should make sure there are no automatically created RDS instances running before attempting to destroy a cluster.
 
 ## Breaking changes
 
 * Version 4.0.0 onwards will only support Terraform 0.12 and above.
-* As of version 3.0.0 of the module the rds-enhanced-monitoring role is now named using a name_prefix instead of a name. This will result in the role being recreated with a new name when you update to it.
+* As of version 3.0.0 of the module the rds-enhanced-monitoring role is now named using a name\_prefix instead of a name. This will result in the role being recreated with a new name when you update to it.
+
+## Usage examples
+
+*It is recommended you always create a parameter group, even if it exactly matches the defaults.*
+
+Changing the parameter group in use requires a restart of the DB cluster, modifying parameters within a group  
+may not (depending on the parameter being altered)
 
 ### Aurora 1.x (MySQL 5.6)
 
@@ -47,7 +42,9 @@ resource "aws_sns_topic" "db_alarms_56" {
 }
 
 module "aurora_db_56" {
-  source                              = "../.."
+  source  = "claranet/aurora/aws"
+  version = "x.y.z"
+
   name                                = "test-aurora-db-56"
   envname                             = "test56"
   envtype                             = "test"
@@ -63,7 +60,7 @@ module "aurora_db_56" {
   storage_encrypted                   = "true"
   apply_immediately                   = "true"
   monitoring_interval                 = "10"
-  cw_alarms                           = true
+  cw_alarms                           = "true"
   cw_sns_topic                        = aws_sns_topic.db_alarms_56.id
   db_parameter_group_name             = aws_db_parameter_group.aurora_db_56_parameter_group.id
   db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_cluster_56_parameter_group.id
@@ -91,7 +88,9 @@ resource "aws_sns_topic" "db_alarms" {
 }
 
 module "aurora_db_57" {
-  source                              = "../.."
+  source  = "claranet/aurora/aws"
+  version = "x.y.z"
+
   engine                              = "aurora-mysql"
   engine-version                      = "5.7.12"
   name                                = "test-aurora-db-57"
@@ -109,7 +108,7 @@ module "aurora_db_57" {
   storage_encrypted                   = "true"
   apply_immediately                   = "true"
   monitoring_interval                 = "10"
-  cw_alarms                           = true
+  cw_alarms                           = "true"
   cw_sns_topic                        = aws_sns_topic.db_alarms.id
   db_parameter_group_name             = aws_db_parameter_group.aurora_db_57_parameter_group.id
   db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id
@@ -128,6 +127,7 @@ resource "aws_rds_cluster_parameter_group" "aurora_57_cluster_parameter_group" {
   description = "test-aurora-57-cluster-parameter-group"
 }
 ```
+
 ### Aurora PostgreSQL
 
 ```hcl
@@ -136,7 +136,9 @@ resource "aws_sns_topic" "db_alarms_postgres96" {
 }
 
 module "aurora_db_postgres96" {
-  source                              = "../.."
+  source  = "claranet/aurora/aws"
+  version = "x.y.z"
+
   engine                              = "aurora-postgresql"
   engine-version                      = "9.6.6"
   name                                = "test-aurora-db-postgres96"
@@ -154,7 +156,7 @@ module "aurora_db_postgres96" {
   storage_encrypted                   = "true"
   apply_immediately                   = "true"
   monitoring_interval                 = "10"
-  cw_alarms                           = true
+  cw_alarms                           = "true"
   cw_sns_topic                        = aws_sns_topic.db_alarms_postgres96.id
   db_parameter_group_name             = aws_db_parameter_group.aurora_db_postgres96_parameter_group.id
   db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id
@@ -173,61 +175,74 @@ resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres96_parameter_
   description = "test-aurora-postgres96-cluster-parameter-group"
 }
 ```
+
+<!--
+The Inputs and Outputs sections below are automatically generated in the master branch,
+so don't bother manually changing them.
+-->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | string | `"false"` | no |
-| auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `"true"` | no |
-| azs | List of AZs to use | list(string) | n/a | yes |
-| backup\_retention\_period | How long to keep backups for (in days) | string | `"7"` | no |
-| cw\_alarms | Whether to enable CloudWatch alarms - requires `cw_sns_topic` is specified | string | `"false"` | no |
-| cw\_eval\_period\_connections | Evaluation period for the DB connections alarms | string | `"1"` | no |
-| cw\_eval\_period\_cpu | Evaluation period for the DB CPU alarms | string | `"2"` | no |
-| cw\_eval\_period\_replica\_lag | Evaluation period for the DB replica lag alarm | string | `"5"` | no |
-| cw\_max\_conns | Connection count beyond which to trigger a CloudWatch alarm | string | `"500"` | no |
-| cw\_max\_cpu | CPU threshold above which to alarm | string | `"85"` | no |
-| cw\_max\_replica\_lag | Maximum Aurora replica lag in milliseconds above which to alarm | string | `"2000"` | no |
-| cw\_sns\_topic | An SNS topic to publish CloudWatch alarms to | string | `"false"` | no |
-| db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | string | `"default.aurora5.6"` | no |
-| db\_parameter\_group\_name | The name of a DB parameter group to use | string | `"default.aurora5.6"` | no |
-| enabled | Whether the database resources should be created | string | `"true"` | no |
-| engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | string | `"aurora"` | no |
-| engine-version | Aurora database engine version. | string | `"5.6.10a"` | no |
-| envname | Environment name (eg,test, stage or prod) | string | n/a | yes |
-| envtype | Environment type (eg,prod or nonprod) | string | n/a | yes |
-| final\_snapshot\_identifier | The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | string | `"final"` | no |
-| iam\_database\_authentication\_enabled | Whether to enable IAM database authentication for the RDS Cluster | string | `"false"` | no |
-| identifier\_prefix | Prefix for cluster and instance identifier | string | `""` | no |
-| instance\_type | Instance type to use | string | `"db.t2.small"` | no |
-| monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | string | `"0"` | no |
-| name | Name given to DB subnet group | string | n/a | yes |
-| password | Master DB password | string | n/a | yes |
-| performance\_insights\_enabled | Whether to enable Performance Insights | string | `"false"` | no |
-| port | The port on which to accept connections | string | `"3306"` | no |
-| preferred\_backup\_window | When to perform DB backups | string | `"02:00-03:00"` | no |
-| preferred\_maintenance\_window | When to perform DB maintenance | string | `"sun:05:00-sun:06:00"` | no |
-| publicly\_accessible | Whether the DB should have a public IP address | string | `"false"` | no |
-| replica\_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | string | `"0"` | no |
-| replica\_scale\_cpu | CPU usage to trigger autoscaling at | string | `"70"` | no |
-| replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | string | `"false"` | no |
-| replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | string | `"300"` | no |
-| replica\_scale\_max | Maximum number of replicas to allow scaling for | string | `"0"` | no |
-| replica\_scale\_min | Maximum number of replicas to allow scaling for | string | `"2"` | no |
-| replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | string | `"300"` | no |
-| security\_groups | VPC Security Group IDs | list(string) | n/a | yes |
-| skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | string | `"false"` | no |
-| snapshot\_identifier | DB snapshot to create this database from | string | `""` | no |
-| storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | string | `"true"` | no |
-| subnets | List of subnet IDs to use | list(string) | n/a | yes |
-| username | Master DB username | string | `"root"` | no |
+|------|-------------|------|---------|:-----:|
+| azs | List of AZs to use | `list(string)` | n/a | yes |
+| envname | Environment name (eg,test, stage or prod) | `string` | n/a | yes |
+| envtype | Environment type (eg,prod or nonprod) | `string` | n/a | yes |
+| name | Name given to DB subnet group | `string` | n/a | yes |
+| password | Master DB password | `string` | n/a | yes |
+| security\_groups | VPC Security Group IDs | `list(string)` | n/a | yes |
+| subnets | List of subnet IDs to use | `list(string)` | n/a | yes |
+| apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | `string` | `"false"` | no |
+| auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | `string` | `"true"` | no |
+| backup\_retention\_period | How long to keep backups for (in days) | `string` | `"7"` | no |
+| cw\_alarms | Whether to enable CloudWatch alarms - requires `cw_sns_topic` is specified | `string` | `false` | no |
+| cw\_eval\_period\_connections | Evaluation period for the DB connections alarms | `string` | `"1"` | no |
+| cw\_eval\_period\_cpu | Evaluation period for the DB CPU alarms | `string` | `"2"` | no |
+| cw\_eval\_period\_replica\_lag | Evaluation period for the DB replica lag alarm | `string` | `"5"` | no |
+| cw\_max\_conns | Connection count beyond which to trigger a CloudWatch alarm | `string` | `"500"` | no |
+| cw\_max\_cpu | CPU threshold above which to alarm | `string` | `"85"` | no |
+| cw\_max\_replica\_lag | Maximum Aurora replica lag in milliseconds above which to alarm | `string` | `"2000"` | no |
+| cw\_sns\_topic | An SNS topic to publish CloudWatch alarms to | `string` | `"false"` | no |
+| db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | `string` | `"default.aurora5.6"` | no |
+| db\_parameter\_group\_name | The name of a DB parameter group to use | `string` | `"default.aurora5.6"` | no |
+| enabled | Whether the database resources should be created | `string` | `true` | no |
+| engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | `string` | `"aurora"` | no |
+| engine-version | Aurora database engine version. | `string` | `"5.6.10a"` | no |
+| final\_snapshot\_identifier | The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
+| iam\_database\_authentication\_enabled | Whether to enable IAM database authentication for the RDS Cluster | `string` | `false` | no |
+| identifier\_prefix | Prefix for cluster and instance identifier | `string` | `""` | no |
+| instance\_type | Instance type to use | `string` | `"db.t2.small"` | no |
+| monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `string` | `0` | no |
+| performance\_insights\_enabled | Whether to enable Performance Insights | `string` | `false` | no |
+| port | The port on which to accept connections | `string` | `"3306"` | no |
+| preferred\_backup\_window | When to perform DB backups | `string` | `"02:00-03:00"` | no |
+| preferred\_maintenance\_window | When to perform DB maintenance | `string` | `"sun:05:00-sun:06:00"` | no |
+| publicly\_accessible | Whether the DB should have a public IP address | `string` | `"false"` | no |
+| replica\_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | `string` | `"0"` | no |
+| replica\_scale\_cpu | CPU usage to trigger autoscaling at | `string` | `"70"` | no |
+| replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | `string` | `false` | no |
+| replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | `string` | `"300"` | no |
+| replica\_scale\_max | Maximum number of replicas to allow scaling for | `string` | `"0"` | no |
+| replica\_scale\_min | Maximum number of replicas to allow scaling for | `string` | `"2"` | no |
+| replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | `string` | `"300"` | no |
+| skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | `string` | `"false"` | no |
+| snapshot\_identifier | DB snapshot to create this database from | `string` | `""` | no |
+| storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | `string` | `"true"` | no |
+| username | Master DB username | `string` | `"root"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| all\_instance\_endpoints\_list | Comma separated list of all DB instance endpoints running in cluster |
+| all\_instance\_endpoints\_list | List of all DB instance endpoints running in cluster |
 | cluster\_endpoint | The 'writer' endpoint for the cluster |
 | cluster\_identifier | The ID of the RDS Cluster |
 | reader\_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Contributing
+
+Ensure any variables you add have a type and description.
+
+Ensure your code is neat by running `terraform fmt` and fixing any missing or unnecessary whitespace.


### PR DESCRIPTION
I think we stopped using it because it didn't support Terraform 0.12.x syntax. Recent versions now support it.