### PR TITLE
Make Enhanced Monitoring IAM role prefix to be configurable variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ so don't bother manually changing them.
 | enabled\_cloudwatch\_logs\_exports | List of log types to export to CloudWatch Logs. If omitted, no logs will be exported. The following log types are supported: audit, error, general, slowquery, postgresql. | `list(string)` | `[]` | no |
 | engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | `string` | `"aurora"` | no |
 | engine-version | Aurora database engine version. | `string` | `"5.6.10a"` | no |
+| enhanced_monitoring_iam_role_prefix | Enhanced Monitoring IAM role prefix | `string` | `"rds-enhanced-mon-"` | no |
 | final\_snapshot\_identifier | The name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
 | iam\_database\_authentication\_enabled | Whether to enable IAM database authentication for the RDS Cluster | `string` | `false` | no |
 | identifier\_prefix | Prefix for cluster and instance identifier | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ data "aws_iam_policy_document" "monitoring-rds-assume-role-policy" {
 
 resource "aws_iam_role" "rds-enhanced-monitoring" {
   count              = var.enabled && var.monitoring_interval > 0 ? 1 : 0
-  name_prefix        = "rds-enhanced-mon-${var.envname}-"
+  name_prefix        = "${var.enhanced_monitoring_iam_role_prefix}${var.envname}-"
   assume_role_policy = data.aws_iam_policy_document.monitoring-rds-assume-role-policy[0].json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -141,8 +141,8 @@ variable "storage_encrypted" {
 }
 
 variable "kms_key_id" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Specify the KMS Key to use for encryption"
 }
 
@@ -264,4 +264,10 @@ variable "enabled_cloudwatch_logs_exports" {
   type        = list(string)
   default     = []
   description = "List of log types to export to CloudWatch Logs. If omitted, no logs will be exported. The following log types are supported: audit, error, general, slowquery, postgresql."
+}
+
+variable "enhanced_monitoring_iam_role_prefix" {
+  type        = string
+  default     = "rds-enhanced-mon-"
+  description = "RDS Enhanced Monitoring IAM role name prefix"
 }


### PR DESCRIPTION
There is a limit of 32 characters for IAM role prefix and terraform will throw an error like this when that happens:

```
Error: module.aurora_hint.aws_iam_role.rds-enhanced-monitoring: "name_prefix" cannot be longer than 32 characters, name is limited to 64
```

The hardcoded prefix was already using up 19 out of 32 allowed characters.

Making this as a configurable variable with backwards compatibility.